### PR TITLE
Update stageprompt.js

### DIFF
--- a/javascripts/stageprompt.js
+++ b/javascripts/stageprompt.js
@@ -62,7 +62,11 @@
   }())
 
   GOVUK.performance.sendGoogleAnalyticsEvent = function (category, event, label) {
-    global._gaq.push(['_trackEvent', category, event, label, undefined, true])
+    if (window.ga && typeof(window.ga) === 'function') {
+      ga('send', 'event', category, event, label)
+    } else {
+      _gaq.push(['_trackEvent', category, event, label, undefined, true])
+    }    
   }
 
   global.GOVUK = GOVUK


### PR DESCRIPTION
Update to enable support for the latest Google Analytics Events api inline with https://github.com/alphagov/stageprompt